### PR TITLE
FIX: 계좌 내역 등록 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/account/AccountService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/account/AccountService.java
@@ -40,4 +40,12 @@ public class AccountService {
         Account defaultAccount = accountRepository.getDefaultAccount();
         return new AccountBalance().balance(defaultAccount.getBalance());
     }
+
+    public Account getDefaultAccount() {
+        return accountRepository.getDefaultAccount();
+    }
+
+    public void updateBalance(Double balance) {
+
+    }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -1,5 +1,6 @@
 package com.github.kellyihyeon.stanceadmin.application.accounttransaction;
 
+import com.github.kellyihyeon.stanceadmin.application.account.AccountService;
 import com.github.kellyihyeon.stanceadmin.application.accounttransaction.dto.MemberShipFeeDepositCreation;
 import com.github.kellyihyeon.stanceadmin.domain.account.AccountRepository;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.*;
@@ -16,6 +17,43 @@ public class AccountTransactionService {
 
     private final AccountTransactionRepository repository;
     private final AccountRepository accountRepository;
+
+    private final AccountService accountService;
+
+
+    @Transactional
+    public void saveDepositAccountTransaction() {
+        // 파라미터 객체
+        Long transactionId = 1L;
+        TransactionType transactionType = TransactionType.DEPOSIT;
+        TransactionSubType transactionSubType = TransactionSubType.EVENT;
+        Double amount = (double) 70000;
+
+        // 유저 객체
+        LocalDateTime now = LocalDateTime.now();
+        Long loggedInId = 999L;
+
+        Long defaultAccountId = accountService.getDefaultAccount().getId();
+        AccountTransaction accountTransaction = AccountTransaction.create(
+                null,
+                defaultAccountId,
+                transactionType,
+                transactionId,
+                transactionSubType,
+                amount,
+                now,
+                loggedInId
+        );
+
+        Double balance = accountTransaction.addAmountToBalance(getLatestBalance());
+        repository.createAccountTransaction(accountTransaction);
+
+        accountService.updateBalance(balance);
+    }
+
+    private Double getLatestBalance() {
+        return repository.findLatestAccountTransaction().getBalance();
+    }
 
     @Transactional
     public void createMembershipFeeDepositTransaction(MemberShipFeeDepositCreation serviceDto) {

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -35,7 +35,6 @@ public class AccountTransactionService {
 
         Long defaultAccountId = accountService.getDefaultAccount().getId();
         AccountTransaction accountTransaction = AccountTransaction.create(
-                null,
                 defaultAccountId,
                 transactionType,
                 transactionId,

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -22,13 +22,7 @@ public class AccountTransactionService {
 
 
     @Transactional
-    public void saveDepositAccountTransaction() {
-        // 파라미터 객체
-        Long transactionId = 1L;
-        TransactionType transactionType = TransactionType.DEPOSIT;
-        TransactionSubType transactionSubType = TransactionSubType.EVENT;
-        Double amount = (double) 70000;
-
+    public void saveDepositAccountTransaction(TransactionIdentity transactionIdentity, Double amount) {
         // 유저 객체
         LocalDateTime now = LocalDateTime.now();
         Long loggedInId = 999L;
@@ -36,9 +30,9 @@ public class AccountTransactionService {
         Long defaultAccountId = accountService.getDefaultAccount().getId();
         AccountTransaction accountTransaction = AccountTransaction.create(
                 defaultAccountId,
-                transactionType,
-                transactionId,
-                transactionSubType,
+                transactionIdentity.getType(),
+                transactionIdentity.getTransactionId(),
+                transactionIdentity.getSubtype(),
                 amount,
                 now,
                 loggedInId

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -74,10 +74,12 @@ public class AccountTransaction {
     }
 
     public Double addAmountToBalance(Double latestBalance) {
-        return null;
+        this.balance = latestBalance + this.amount;
+        return this.balance;
     }
 
     public Double subtractAmountFromBalance(Double latestBalance) {
-        return null;
+        this.balance = latestBalance - this.amount;
+        return this.balance;
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -21,6 +21,10 @@ public class AccountTransaction {
 
     private TransactionSubType transactionSubType;
 
+    private Double amount;
+
+    private Double balance;
+
     private LocalDateTime createdAt;
 
     private Long creatorId;
@@ -31,6 +35,17 @@ public class AccountTransaction {
         this.transactionType = transactionType;
         this.transactionId = transactionId;
         this.transactionSubType = transactionSubType;
+        this.createdAt = createdAt;
+        this.creatorId = creatorId;
+    }
+
+    private AccountTransaction(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
+        this.id = id;
+        this.accountId = accountId;
+        this.transactionType = transactionType;
+        this.transactionId = transactionId;
+        this.transactionSubType = transactionSubType;
+        this.amount = amount;
         this.createdAt = createdAt;
         this.creatorId = creatorId;
     }
@@ -46,7 +61,27 @@ public class AccountTransaction {
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, createdAt, creatorId);
     }
 
-    public Double calculateBalance(Double latestBalance, TransactionType deposit) {
-        return (double) 0;
+    public static AccountTransaction create(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
+        Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionType, "transactionType 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionId, "transactionId 가 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionSubType, "transactionSubType 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(amount, "amount 가 null 이어서는 안됩니다.");
+        Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
+
+        return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, createdAt, creatorId);
+    }
+
+    public Double calculateBalance(Double latestBalance, TransactionType transactionType) {
+        if (TransactionType.DEPOSIT.equals(transactionType)) {
+            this.balance = latestBalance + this.amount;
+        }
+
+        if (TransactionType.WITHDRAW.equals(transactionType)) {
+            this.balance = latestBalance - this.amount;
+        }
+
+        return this.balance;
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -45,4 +45,8 @@ public class AccountTransaction {
 
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, createdAt, creatorId);
     }
+
+    public Double calculateBalance(Double latestBalance, TransactionType deposit) {
+        return (double) 0;
+    }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -73,15 +73,11 @@ public class AccountTransaction {
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, createdAt, creatorId);
     }
 
-    public Double calculateBalance(Double latestBalance, TransactionType transactionType) {
-        if (TransactionType.DEPOSIT.equals(transactionType)) {
-            this.balance = latestBalance + this.amount;
-        }
+    public Double addAmountToBalance(Double latestBalance) {
+        return null;
+    }
 
-        if (TransactionType.WITHDRAW.equals(transactionType)) {
-            this.balance = latestBalance - this.amount;
-        }
-
-        return this.balance;
+    public Double subtractAmountFromBalance(Double latestBalance) {
+        return null;
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -39,8 +39,7 @@ public class AccountTransaction {
         this.creatorId = creatorId;
     }
 
-    private AccountTransaction(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
-        this.id = id;
+    private AccountTransaction(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
         this.accountId = accountId;
         this.transactionType = transactionType;
         this.transactionId = transactionId;
@@ -61,7 +60,7 @@ public class AccountTransaction {
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, createdAt, creatorId);
     }
 
-    public static AccountTransaction create(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
+    public static AccountTransaction create(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
         Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
         Objects.requireNonNull(transactionType, "transactionType 이 null 이어서는 안됩니다.");
         Objects.requireNonNull(transactionId, "transactionId 가 null 이어서는 안됩니다.");
@@ -70,7 +69,7 @@ public class AccountTransaction {
         Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
         Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
 
-        return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, createdAt, creatorId);
+        return new AccountTransaction(accountId, transactionType, transactionId, transactionSubType, amount, createdAt, creatorId);
     }
 
     public Double addAmountToBalance(Double latestBalance) {

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionRepository.java
@@ -5,4 +5,6 @@ public interface AccountTransactionRepository {
     Long createMembershipFeeDepositTransaction(MembershipFeeDepositTransaction domain);
 
     void createAccountTransaction(AccountTransaction accountTransaction);
+
+    AccountTransaction findLatestAccountTransaction();
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TransactionIdentity {
@@ -16,9 +18,16 @@ public class TransactionIdentity {
 
 
     private TransactionIdentity(Long transactionId, TransactionType type, TransactionSubType subtype) {
+        this.transactionId = transactionId;
+        this.type = type;
+        this.subtype = subtype;
     }
 
-    public TransactionIdentity createDeposit(Long transactionId, TransactionType type, TransactionSubType subtype) {
-        return null;
+    public TransactionIdentity create(Long transactionId, TransactionType type, TransactionSubType subtype) {
+        Objects.requireNonNull(transactionId, "transactionId 가 null 이어선 안됩니다.");
+        Objects.requireNonNull(type, "type 이 null 이어선 안됩니다.");
+        Objects.requireNonNull(subtype, "subtype 이 null 이어선 안됩니다.");
+
+        return new TransactionIdentity(transactionId, type, subtype);
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
@@ -1,0 +1,24 @@
+package com.github.kellyihyeon.stanceadmin.domain.accounttransaction;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TransactionIdentity {
+
+    private Long transactionId;
+
+    private TransactionType type;
+
+    private TransactionSubType subtype;
+
+
+    private TransactionIdentity(Long transactionId, TransactionType type, TransactionSubType subtype) {
+    }
+
+    public TransactionIdentity createDeposit(Long transactionId, TransactionType type, TransactionSubType subtype) {
+        return null;
+    }
+}

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionRepositoryImpl.java
@@ -27,4 +27,9 @@ public class AccountTransactionRepositoryImpl implements AccountTransactionRepos
         AccountTransactionEntity entity = AccountTransactionMapper.toEntity(accountTransaction);
         jpaAccountTransactionRepository.save(entity);
     }
+
+    @Override
+    public AccountTransaction findLatestAccountTransaction() {
+        return null;
+    }
 }

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
@@ -14,6 +14,8 @@ public class AccountTransactionBuilder {
 
     private TransactionSubType transactionSubType = TransactionSubType.MEMBERSHIP_FEE;
 
+    private Double amount = (double) 1000;
+
     private LocalDateTime createdAt = LocalDateTime.now();
 
     private Long creatorId = 999L;
@@ -39,6 +41,11 @@ public class AccountTransactionBuilder {
 
     public AccountTransactionBuilder transactionSubType(TransactionSubType transactionSubType) {
         this.transactionSubType = transactionSubType;
+        return this;
+    }
+
+    public AccountTransactionBuilder amount(Double amount) {
+        this.amount = amount;
         return this;
     }
 

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
@@ -66,6 +66,7 @@ public class AccountTransactionBuilder {
                 transactionType,
                 transactionId,
                 transactionSubType,
+                amount,
                 createdAt,
                 creatorId
         );

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
@@ -61,7 +61,6 @@ public class AccountTransactionBuilder {
 
     public AccountTransaction build() {
         return AccountTransaction.create(
-                id,
                 accountId,
                 transactionType,
                 transactionId,

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
@@ -9,16 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AccountTransactionTest {
 
     @Test
-    void 입금_내역과_관련된_transaction_객체를_생성() {
-        Long transactionId = 5L;
-        TransactionType type = TransactionType.DEPOSIT;
-        TransactionSubType subType = TransactionSubType.EVENT;
-
-        TransactionIdentity transactionIdentity = new TransactionIdentity();
-        TransactionIdentity depositTransaction = transactionIdentity.createDeposit(transactionId, type, subType);
+    @DisplayName("트랜잭션을 다루는 객체를 생성한다.")
+    void 트랜잭션_객체_생성() {
+        TransactionIdentity depositTransaction = new TransactionIdentity().create(5L, TransactionType.DEPOSIT, TransactionSubType.EVENT);
 
         assertEquals(5L, depositTransaction.getTransactionId());
         assertEquals(TransactionType.DEPOSIT, depositTransaction.getType());
+
+        TransactionIdentity withdrawalTransaction = new TransactionIdentity().create(6L, TransactionType.WITHDRAW, TransactionSubType.TRANSFER);
+
+        assertEquals(6L, withdrawalTransaction.getTransactionId());
+        assertEquals(TransactionType.WITHDRAW, withdrawalTransaction.getType());
     }
 
     @Test

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
@@ -9,6 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AccountTransactionTest {
 
     @Test
+    void 입금_내역과_관련된_transaction_객체를_생성() {
+        Long transactionId = 5L;
+        TransactionType type = TransactionType.DEPOSIT;
+        TransactionSubType subType = TransactionSubType.EVENT;
+
+        TransactionIdentity transactionIdentity = new TransactionIdentity();
+        TransactionIdentity depositTransaction = transactionIdentity.createDeposit(transactionId, type, subType);
+
+        assertEquals(5L, depositTransaction.getTransactionId());
+        assertEquals(TransactionType.DEPOSIT, depositTransaction.getType());
+    }
+
+    @Test
     @DisplayName("출금 내역인 경우 최신 잔액에서 출금액을 빼서 계산하다.")
     void 출금_내역인_경우_잔액() {
         Double latestBalance = (double) 100000;

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
@@ -3,9 +3,24 @@ package com.github.kellyihyeon.stanceadmin.domain.accounttransaction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AccountTransactionTest {
+
+    @Test
+    @DisplayName("입금인 경우 최신 잔액에 입금액을 더한다.")
+    void 입금_내역의_경우_잔액_계산하기() {
+        Double latestBalance = (double) 100000;
+        AccountTransaction accountTransaction = AccountTransactionBuilder.builder()
+                .amount((double) 70000)
+                .build();
+
+        Double actualBalance = accountTransaction.calculateBalance(latestBalance, TransactionType.DEPOSIT);
+        Double expectedBalance = (double) 170000;
+
+        assertEquals(expectedBalance, actualBalance);
+    }
 
     @Test
     @DisplayName("accountId 가 null 이면 NullPointerException이 발생한다.")

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
@@ -9,14 +9,29 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AccountTransactionTest {
 
     @Test
-    @DisplayName("입금인 경우 최신 잔액에 입금액을 더한다.")
-    void 입금_내역의_경우_잔액_계산하기() {
+    @DisplayName("출금 내역인 경우 최신 잔액에서 출금액을 빼서 계산하다.")
+    void 출금_내역인_경우_잔액() {
         Double latestBalance = (double) 100000;
         AccountTransaction accountTransaction = AccountTransactionBuilder.builder()
                 .amount((double) 70000)
                 .build();
 
-        Double actualBalance = accountTransaction.calculateBalance(latestBalance, TransactionType.DEPOSIT);
+        Double actualBalance = accountTransaction.subtractAmountFromBalance(latestBalance);
+        Double expectedBalance = (double) 30000;
+
+        assertEquals(expectedBalance, actualBalance);
+
+    }
+
+    @Test
+    @DisplayName("입금 내역인 경우 최신 잔액에서 입금액을 더해서 계산한다.")
+    void 입금_내역인_경우_잔액() {
+        Double latestBalance = (double) 100000;
+        AccountTransaction accountTransaction = AccountTransactionBuilder.builder()
+                .amount((double) 70000)
+                .build();
+
+        Double actualBalance = accountTransaction.addAmountToBalance(latestBalance);
         Double expectedBalance = (double) 170000;
 
         assertEquals(expectedBalance, actualBalance);


### PR DESCRIPTION
# 수정 사항
- 입금인 경우 계좌내역의 잔액을 계산하는 기능 추가
    - 최신 잔액 + 입금액
- 출금인 경우 계좌내역의 잔액을 계산하는 기능 추가
     - 최신 잔액 - 출금액
- 계좌 내역 등록 시 필요한 트랜잭션 관련 파라미터를 객체로 받을 수 있게 수정