### PR TITLE
이벤트 입금 내역 등록 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventapplicantregistry/EventApplicantRegistryService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventapplicantregistry/EventApplicantRegistryService.java
@@ -41,4 +41,14 @@ public class EventApplicantRegistryService {
             );
         }
     }
+
+    public void processDepositCompletion(Long eventId, List<Long> depositorIds) {
+        List<EventApplicantRegistry> eventApplicantRegistries = eventApplicantRegistryRepository.getRegistriesByEventIdAndDepositorIds(eventId, depositorIds);
+
+        for (EventApplicantRegistry registry : eventApplicantRegistries) {
+            registry.markAsPaid();
+        }
+
+        eventApplicantRegistryRepository.saveAll(eventApplicantRegistries);
+    }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapper.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapper.java
@@ -1,19 +1,16 @@
 package com.github.kellyihyeon.stanceadmin.application.eventdeposit;
 
+import com.github.kellyihyeon.stanceadmin.application.eventdeposit.dto.EventDepositCreation;
 import com.github.kellyihyeon.stanceadmin.domain.eventdeposit.EventDepositTransaction;
 import com.github.kellyihyeon.stanceadmin.infrastructure.repository.eventdeposit.EventDepositTransactionEntity;
 
-public class EventDepositTransactionMapper {
+import java.time.LocalDateTime;
+import java.util.List;
 
-    public static EventDepositTransactionEntity toEntity(EventDepositTransaction domain) {
-        return EventDepositTransactionEntity.create(
-                domain.getEventId(),
-                domain.getApplicantId(),
-                domain.getAmount(),
-                domain.getDepositDate(),
-                domain.getDescription(),
-                domain.getCreatedAt(),
-                domain.getCreatorId()
-        );
-    }
+public interface EventDepositTransactionMapper {
+
+    EventDepositTransactionEntity toEntity(EventDepositTransaction domain);
+
+    List<EventDepositTransaction> toDomains(EventDepositCreation serviceDto, Long loggedInId, LocalDateTime now);
+
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
@@ -16,7 +16,7 @@ public class EventDepositTransactionMapperImpl implements EventDepositTransactio
     public EventDepositTransactionEntity toEntity(EventDepositTransaction domain) {
         return EventDepositTransactionEntity.create(
                 domain.getEventId(),
-                domain.getApplicantId(),
+                domain.getDepositorId(),
                 domain.getAmount(),
                 domain.getDepositDate(),
                 domain.getDescription(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
@@ -30,8 +30,7 @@ public class EventDepositTransactionMapperImpl implements EventDepositTransactio
         List<EventDepositTransaction> result = new ArrayList<>();
 
         for (Long depositorId : serviceDto.getDepositorIds()) {
-            result.add(EventDepositTransaction.create(
-                    null,
+            result.add(EventDepositTransaction.createWithoutId(
                     serviceDto.getEventId(),
                     depositorId,
                     serviceDto.getAmount(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
@@ -1,0 +1,32 @@
+package com.github.kellyihyeon.stanceadmin.application.eventdeposit;
+
+import com.github.kellyihyeon.stanceadmin.application.eventdeposit.dto.EventDepositCreation;
+import com.github.kellyihyeon.stanceadmin.domain.eventdeposit.EventDepositTransaction;
+import com.github.kellyihyeon.stanceadmin.infrastructure.repository.eventdeposit.EventDepositTransactionEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class EventDepositTransactionMapperImpl implements EventDepositTransactionMapper {
+
+    @Override
+    public EventDepositTransactionEntity toEntity(EventDepositTransaction domain) {
+        return EventDepositTransactionEntity.create(
+                domain.getEventId(),
+                domain.getApplicantId(),
+                domain.getAmount(),
+                domain.getDepositDate(),
+                domain.getDescription(),
+                domain.getCreatedAt(),
+                domain.getCreatorId()
+        );
+    }
+
+    @Override
+    public List<EventDepositTransaction> toDomains(EventDepositCreation serviceDto, Long loggedInId, LocalDateTime now) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionMapperImpl.java
@@ -6,6 +6,7 @@ import com.github.kellyihyeon.stanceadmin.infrastructure.repository.eventdeposit
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -26,7 +27,22 @@ public class EventDepositTransactionMapperImpl implements EventDepositTransactio
 
     @Override
     public List<EventDepositTransaction> toDomains(EventDepositCreation serviceDto, Long loggedInId, LocalDateTime now) {
-        return null;
+        List<EventDepositTransaction> result = new ArrayList<>();
+
+        for (Long depositorId : serviceDto.getDepositorIds()) {
+            result.add(EventDepositTransaction.create(
+                    null,
+                    serviceDto.getEventId(),
+                    depositorId,
+                    serviceDto.getAmount(),
+                    serviceDto.getDepositDate(),
+                    serviceDto.getDescription(),
+                    loggedInId,
+                    now
+            ));
+        }
+
+        return result;
     }
 
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
@@ -41,7 +41,7 @@ public class EventDepositTransactionService {
             Long transactionId = repository.saveEventDepositTransaction(
                     EventDepositTransaction.createWithoutId(
                             eventDepositTransaction.getEventId(),
-                            eventDepositTransaction.getApplicantId(),
+                            eventDepositTransaction.getDepositorId(),
                             eventDepositTransaction.getAmount(),
                             eventDepositTransaction.getDepositDate(),
                             eventDepositTransaction.getDescription(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
@@ -20,9 +20,11 @@ import java.util.List;
 public class EventDepositTransactionService {
 
     private final EventDepositTransactionRepository repository;
-    private final AccountTransactionService accountTransactionService;
+    private final EventDepositTransactionMapper mapper;
 
+    private final AccountTransactionService accountTransactionService;
     private final EventService eventService;
+
 
 
     @Transactional
@@ -33,7 +35,7 @@ public class EventDepositTransactionService {
 
         Long loggedInId = 999L;
         LocalDateTime now = LocalDateTime.now();
-        List<EventDepositTransaction> transactions = serviceDto.toDomains(loggedInId, now);
+        List<EventDepositTransaction> transactions = mapper.toDomains(serviceDto, loggedInId, now);
 
         for (EventDepositTransaction eventDepositTransaction : transactions) {
             Long transactionId = repository.saveEventDepositTransaction(

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
@@ -2,6 +2,7 @@ package com.github.kellyihyeon.stanceadmin.application.eventdeposit;
 
 import com.github.kellyihyeon.stanceadmin.application.accounttransaction.AccountTransactionService;
 import com.github.kellyihyeon.stanceadmin.application.event.EventService;
+import com.github.kellyihyeon.stanceadmin.application.eventapplicantregistry.EventApplicantRegistryService;
 import com.github.kellyihyeon.stanceadmin.application.eventdeposit.dto.EventDepositCreation;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionIdentity;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionSubType;
@@ -24,6 +25,8 @@ public class EventDepositTransactionService {
 
     private final AccountTransactionService accountTransactionService;
     private final EventService eventService;
+
+    private final EventApplicantRegistryService eventApplicantRegistryService;
 
 
 
@@ -49,6 +52,8 @@ public class EventDepositTransactionService {
                             now
                     )
             );
+
+            eventApplicantRegistryService.processDepositCompletion(serviceDto.getEventId(), serviceDto.getDepositorIds());
 
             accountTransactionService.saveAccountTransaction(
                     TransactionIdentity.create(transactionId, TransactionType.DEPOSIT, TransactionSubType.EVENT),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventDepositTransactionService.java
@@ -39,8 +39,7 @@ public class EventDepositTransactionService {
 
         for (EventDepositTransaction eventDepositTransaction : transactions) {
             Long transactionId = repository.saveEventDepositTransaction(
-                    new EventDepositTransaction(
-                            eventDepositTransaction.getId(),
+                    EventDepositTransaction.createWithoutId(
                             eventDepositTransaction.getEventId(),
                             eventDepositTransaction.getApplicantId(),
                             eventDepositTransaction.getAmount(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/dto/EventDepositCreation.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/dto/EventDepositCreation.java
@@ -1,11 +1,8 @@
 package com.github.kellyihyeon.stanceadmin.application.eventdeposit.dto;
 
-import com.github.kellyihyeon.stanceadmin.domain.eventdeposit.EventDepositTransaction;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,24 +33,5 @@ public class EventDepositCreation {
         Objects.requireNonNull(depositDate, "depositDate 는 null 이어선 안됩니다.");
 
         return new EventDepositCreation(eventId, depositorIds, amount, depositDate, description);
-    }
-
-    public List<EventDepositTransaction> toDomains(Long loggedInId, LocalDateTime now) {
-        List<EventDepositTransaction> transactions = new ArrayList<>();
-
-        for (Long depositorId : depositorIds) {
-            transactions.add(EventDepositTransaction.create(
-                    null,
-                    this.eventId,
-                    depositorId,
-                    this.amount,
-                    this.depositDate,
-                    this.description,
-                    loggedInId,
-                    now
-            ));
-        }
-
-        return transactions;
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventapplicantregistry/EventApplicantRegistryRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventapplicantregistry/EventApplicantRegistryRepository.java
@@ -8,4 +8,6 @@ public interface EventApplicantRegistryRepository {
 
     List<EventApplicantRegistry> getRegistriesByEventIdAndDepositorIds(Long eventId, List<Long> depositorIds);
 
+    void saveAll(List<EventApplicantRegistry> eventApplicantRegistries);
+
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventapplicantregistry/EventApplicantRegistryRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventapplicantregistry/EventApplicantRegistryRepository.java
@@ -1,7 +1,11 @@
 package com.github.kellyihyeon.stanceadmin.domain.eventapplicantregistry;
 
+import java.util.List;
+
 public interface EventApplicantRegistryRepository {
 
     void createEventApplicant(EventApplicantRegistry eventApplicantRegistry);
+
+    List<EventApplicantRegistry> getRegistriesByEventIdAndDepositorIds(Long eventId, List<Long> depositorIds);
 
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
@@ -44,6 +44,16 @@ public class EventDepositTransaction {
         this.createdAt = createdAt;
     }
 
+    private EventDepositTransaction(Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.applicantId = applicantId;
+        this.amount = amount;
+        this.depositDate = depositDate;
+        this.description = description;
+        this.creatorId = creatorId;
+        this.createdAt = createdAt;
+    }
+
     public static EventDepositTransaction create(Long id, Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
         Objects.requireNonNull(eventId, "eventId 는 null 이어선 안됩니다.");
         Objects.requireNonNull(applicantId, "applicantId 는 null 이어선 안됩니다.");
@@ -56,6 +66,25 @@ public class EventDepositTransaction {
                 id,
                 eventId,
                 applicantId,
+                amount,
+                depositDate,
+                description,
+                creatorId,
+                createdAt
+        );
+    }
+
+    public static EventDepositTransaction createWithoutId(Long eventId, Long depositorId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
+        Objects.requireNonNull(eventId, "eventId 는 null 이어선 안됩니다.");
+        Objects.requireNonNull(depositorId, "depositorId 는 null 이어선 안됩니다.");
+        Objects.requireNonNull(amount, "amount 는 null 이어선 안됩니다.");
+        Objects.requireNonNull(depositDate, "depositDate 는 null 이어선 안됩니다.");
+        Objects.requireNonNull(creatorId, "creatorId 는 null 이어선 안됩니다.");
+        Objects.requireNonNull(createdAt, "createdAt 은 null 이어선 안됩니다.");
+
+        return new EventDepositTransaction(
+                eventId,
+                depositorId,
                 amount,
                 depositDate,
                 description,

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
@@ -14,7 +14,7 @@ public class EventDepositTransaction {
 
     private Long eventId;
 
-    private Long applicantId;
+    private Long depositorId;
 
     private Double amount;
 
@@ -31,9 +31,9 @@ public class EventDepositTransaction {
     private LocalDateTime updatedAt;
 
 
-    private EventDepositTransaction(Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
+    private EventDepositTransaction(Long eventId, Long depositorId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
         this.eventId = eventId;
-        this.applicantId = applicantId;
+        this.depositorId = depositorId;
         this.amount = amount;
         this.depositDate = depositDate;
         this.description = description;

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransaction.java
@@ -12,8 +12,6 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventDepositTransaction {
 
-    private Long id;
-
     private Long eventId;
 
     private Long applicantId;
@@ -33,17 +31,6 @@ public class EventDepositTransaction {
     private LocalDateTime updatedAt;
 
 
-    public EventDepositTransaction(Long id, Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
-        this.id = id;
-        this.eventId = eventId;
-        this.applicantId = applicantId;
-        this.amount = amount;
-        this.depositDate = depositDate;
-        this.description = description;
-        this.creatorId = creatorId;
-        this.createdAt = createdAt;
-    }
-
     private EventDepositTransaction(Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
         this.eventId = eventId;
         this.applicantId = applicantId;
@@ -52,26 +39,6 @@ public class EventDepositTransaction {
         this.description = description;
         this.creatorId = creatorId;
         this.createdAt = createdAt;
-    }
-
-    public static EventDepositTransaction create(Long id, Long eventId, Long applicantId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {
-        Objects.requireNonNull(eventId, "eventId 는 null 이어선 안됩니다.");
-        Objects.requireNonNull(applicantId, "applicantId 는 null 이어선 안됩니다.");
-        Objects.requireNonNull(amount, "amount 는 null 이어선 안됩니다.");
-        Objects.requireNonNull(depositDate, "depositDate 는 null 이어선 안됩니다.");
-        Objects.requireNonNull(creatorId, "creatorId 는 null 이어선 안됩니다.");
-        Objects.requireNonNull(createdAt, "createdAt 은 null 이어선 안됩니다.");
-
-        return new EventDepositTransaction(
-                id,
-                eventId,
-                applicantId,
-                amount,
-                depositDate,
-                description,
-                creatorId,
-                createdAt
-        );
     }
 
     public static EventDepositTransaction createWithoutId(Long eventId, Long depositorId, Double amount, LocalDate depositDate, String description, Long creatorId, LocalDateTime createdAt) {

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/EventApplicantRegistryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/EventApplicantRegistryRepositoryImpl.java
@@ -27,4 +27,9 @@ public class EventApplicantRegistryRepositoryImpl implements EventApplicantRegis
         return null;
     }
 
+    @Override
+    public void saveAll(List<EventApplicantRegistry> eventApplicantRegistries) {
+
+    }
+
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/EventApplicantRegistryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/EventApplicantRegistryRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.github.kellyihyeon.stanceadmin.domain.eventapplicantregistry.EventApp
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class EventApplicantRegistryRepositoryImpl implements EventApplicantRegistryRepository {
@@ -17,4 +19,12 @@ public class EventApplicantRegistryRepositoryImpl implements EventApplicantRegis
         EventApplicantRegistryEntity entity = EventApplicantRegistryMapper.toEntity(eventApplicantRegistry);
         jpaRepository.save(entity);
     }
+
+    @Override
+    public List<EventApplicantRegistry> getRegistriesByEventIdAndDepositorIds(Long eventId, List<Long> depositorIds) {
+        List<EventApplicantRegistryEntity> entities = jpaRepository.findByEventIdAndApplicantIdIn(eventId, depositorIds);
+
+        return null;
+    }
+
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/JpaEventApplicantRegistryEntityRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventapplicantregistry/JpaEventApplicantRegistryEntityRepository.java
@@ -2,5 +2,9 @@ package com.github.kellyihyeon.stanceadmin.infrastructure.repository.eventapplic
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface JpaEventApplicantRegistryEntityRepository extends JpaRepository<EventApplicantRegistryEntity, Long> {
+
+    List<EventApplicantRegistryEntity> findByEventIdAndApplicantIdIn(Long eventId, List<Long> applicantIds);
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventdeposit/EventDepositTransactionRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/eventdeposit/EventDepositTransactionRepositoryImpl.java
@@ -11,10 +11,11 @@ import org.springframework.stereotype.Repository;
 public class EventDepositTransactionRepositoryImpl implements EventDepositTransactionRepository {
 
     private final JpaEventDepositTransactionEntityRepository jpaRepository;
+    private final EventDepositTransactionMapper mapper;
 
     @Override
     public Long saveEventDepositTransaction(EventDepositTransaction domain) {
-        EventDepositTransactionEntity entity = EventDepositTransactionMapper.toEntity(domain);
+        EventDepositTransactionEntity entity = mapper.toEntity(domain);
         return jpaRepository.save(entity).getId();
     }
 }

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransactionBuilder.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransactionBuilder.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 
 public class EventDepositTransactionBuilder {
 
-    private Long id = 1L;
     private Long eventId = 1L;
     private Long applicantId = 2L;
     private Double amount = (double) 70000L;
@@ -17,12 +16,6 @@ public class EventDepositTransactionBuilder {
 
     public static EventDepositTransactionBuilder builder() {
         return new EventDepositTransactionBuilder();
-    }
-
-
-    public EventDepositTransactionBuilder id(Long id) {
-        this.id = id;
-        return this;
     }
 
     public EventDepositTransactionBuilder eventId(Long eventId) {
@@ -62,8 +55,7 @@ public class EventDepositTransactionBuilder {
     }
 
     public EventDepositTransaction build() {
-        return EventDepositTransaction.create(
-                id,
+        return EventDepositTransaction.createWithoutId(
                 eventId,
                 applicantId,
                 amount,

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/eventdeposit/EventDepositTransactionTest.java
@@ -1,12 +1,12 @@
 package com.github.kellyihyeon.stanceadmin.domain.eventdeposit;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class EventDepositTransactionTest {
@@ -14,7 +14,6 @@ public class EventDepositTransactionTest {
     @Test
     void create() {
         EventDepositTransaction eventDepositTransaction = EventDepositTransactionBuilder.builder()
-                .id(5L)
                 .eventId(1L)
                 .applicantId(2L)
                 .amount((double) 70000)
@@ -23,7 +22,7 @@ public class EventDepositTransactionTest {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        assertThat(eventDepositTransaction.getId()).isEqualTo(5L);
+        Assertions.assertEquals(1L, eventDepositTransaction.getEventId());
     }
 
     @Test
@@ -39,7 +38,7 @@ public class EventDepositTransactionTest {
                 () -> EventDepositTransactionBuilder.builder()
                         .applicantId(null)
                         .build())
-                .isInstanceOf(NullPointerException.class).hasMessageContaining("applicantId 는 null 이어선 안됩니다.");
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("depositorId 는 null 이어선 안됩니다.");
 
         assertThatThrownBy(
                 () -> EventDepositTransactionBuilder.builder()


### PR DESCRIPTION
# 이벤트 입금 내역 도메인 수정 사항
- Mapper를 인터페이스로 만들고 이를 구현하는 객체인 MapperImpl를 생성
- 이벤트 입금 내역 도메인에서 id 필드 삭제
- 신청자 id 필드명을 명확하게 하기 위해 입금자 id로 수정

# 이벤트 신청자 명단 도메인 수정 사항
- repository에서 특정 이벤트, 신청자로 조회하는 메서드 기본 구조 추가
- service에 이벤트 신청자 명단의 입금 상태를 입금 완료로 처리하는 메서드 기본 구조 추가