### PR TITLE
[FIX] 입출금 내역 저장 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -44,13 +45,13 @@ public class AccountTransactionService {
         log.debug("AccountTransaction saved successfully. The event will be triggered. [new balance is {}]", accountTransaction.getBalance());
     }
 
-    private Double getLatestBalance() {
+    private BigDecimal getLatestBalance() {
         AccountTransaction latestAccountTransaction = repository.findLatestAccountTransaction();
 
         if (Objects.isNull(latestAccountTransaction)) {
-            return (double) 0;
+            return BigDecimal.ZERO;
         }
 
-        return latestAccountTransaction.getBalance();
+        return BigDecimal.valueOf(latestAccountTransaction.getBalance());
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -1,7 +1,9 @@
 package com.github.kellyihyeon.stanceadmin.application.accounttransaction;
 
 import com.github.kellyihyeon.stanceadmin.application.account.AccountService;
-import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.*;
+import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.AccountTransaction;
+import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.AccountTransactionRepository;
+import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionIdentity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,9 +39,9 @@ public class AccountTransactionService {
                 loggedInId
         );
 
-        Double balance = accountTransaction.addAmountToBalance(getLatestBalance());
+        accountTransaction.calculateBalance(getLatestBalance());
         repository.saveAccountTransaction(accountTransaction);
-        log.debug("AccountTransaction saved successfully. The event will be triggered. [new balance is {}]", balance);
+        log.debug("AccountTransaction saved successfully. The event will be triggered. [new balance is {}]", accountTransaction.getBalance());
     }
 
     private Double getLatestBalance() {

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -99,6 +99,14 @@ public class AccountTransaction {
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, balance, createdAt, creatorId);
     }
 
+    public Double calculateBalance(Double latestBalance) {
+        if (TransactionType.WITHDRAW.equals(this.transactionType)) {
+            return subtractAmountFromBalance(latestBalance);
+        }
+
+        return addAmountToBalance(latestBalance);
+    }
+
     public Double addAmountToBalance(Double latestBalance) {
         this.balance = latestBalance + this.amount;
         return this.balance;

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -99,7 +100,7 @@ public class AccountTransaction {
         return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, balance, createdAt, creatorId);
     }
 
-    public Double calculateBalance(Double latestBalance) {
+    public BigDecimal calculateBalance(BigDecimal latestBalance) {
         if (TransactionType.WITHDRAW.equals(this.transactionType)) {
             return subtractAmountFromBalance(latestBalance);
         }
@@ -107,13 +108,25 @@ public class AccountTransaction {
         return addAmountToBalance(latestBalance);
     }
 
-    public Double addAmountToBalance(Double latestBalance) {
-        this.balance = latestBalance + this.amount;
-        return this.balance;
+    public BigDecimal addAmountToBalance(BigDecimal latestBalance) {
+        BigDecimal addedBalance = latestBalance.add(BigDecimal.valueOf(this.amount));
+        this.balance = addedBalance.doubleValue();
+
+        return BigDecimal.valueOf(this.balance);
     }
 
-    public Double subtractAmountFromBalance(Double latestBalance) {
-        this.balance = latestBalance - this.amount;
-        return this.balance;
+    public BigDecimal subtractAmountFromBalance(BigDecimal latestBalance) {
+        if (!hasSufficientBalance(latestBalance)) {
+            throw new IllegalArgumentException("잔액이 부족합니다. [현재 잔액: " + latestBalance +"]");
+        }
+
+        BigDecimal subtractedBalance = latestBalance.subtract(BigDecimal.valueOf(this.amount));
+        this.balance = subtractedBalance.doubleValue();
+
+        return BigDecimal.valueOf(this.balance);
+    }
+
+    private boolean hasSufficientBalance(BigDecimal latestBalance) {
+        return latestBalance.compareTo(BigDecimal.valueOf(this.amount)) >= 0;
     }
 }

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionTest.java
@@ -3,6 +3,8 @@ package com.github.kellyihyeon.stanceadmin.domain.accounttransaction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -30,7 +32,8 @@ class AccountTransactionTest {
                 .amount((double) 70000)
                 .build();
 
-        Double actualBalance = accountTransaction.subtractAmountFromBalance(latestBalance);
+        BigDecimal subtractedBalance = accountTransaction.subtractAmountFromBalance(BigDecimal.valueOf(latestBalance));
+        double actualBalance = subtractedBalance.doubleValue();
         Double expectedBalance = (double) 30000;
 
         assertEquals(expectedBalance, actualBalance);
@@ -45,7 +48,8 @@ class AccountTransactionTest {
                 .amount((double) 70000)
                 .build();
 
-        Double actualBalance = accountTransaction.addAmountToBalance(latestBalance);
+        BigDecimal addedBalance = accountTransaction.addAmountToBalance(BigDecimal.valueOf(latestBalance));
+        double actualBalance = addedBalance.doubleValue();
         Double expectedBalance = (double) 170000;
 
         assertEquals(expectedBalance, actualBalance);


### PR DESCRIPTION
# 수정 내용
## as-is
- 입금 및 출금 내역 저장 시 '잔액 = 최신 잔액 + 금액' 으로 업데이트
- 연산 메서드 내에서 잔액 자료형 = Double

## to-be
- 트랜잭션 타입이 출금일 때 '잔액 = 최신 잔액 - 금액' 으로 업데이트
- 최신 잔액이 연산하려는 금액보다 클 때만 연산 실행, 그렇지 않은 경우에는 예외 발생
- - 연산 메서드 내에서 잔액 자료형 = BigDecimal