### PR TITLE
[FIX] 전체 내역 조회하기 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionQueryService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionQueryService.java
@@ -23,6 +23,7 @@ public class AccountTransactionQueryService {
     private final AccountTransactionQueryRepository queryRepository;
 
     public PagedAccountTransactionResponse getAllAccountTransactions(PageRequest pageable) {
+        long totalElements = queryRepository.countTotalElements();
         List<AccountTransactionProjection> projections = queryRepository.findAccountTransactionWithJoins(pageable);
 
         List<AccountTransactionResponse> allAccountTransactions = projections.stream()
@@ -42,7 +43,7 @@ public class AccountTransactionQueryService {
                 .collect(Collectors.toList());
 
 
-        PageImpl<AccountTransactionResponse> pagedTransactions = new PageImpl<>(allAccountTransactions, pageable, allAccountTransactions.size());
+        PageImpl<AccountTransactionResponse> pagedTransactions = new PageImpl<>(allAccountTransactions, pageable, totalElements);
         PagingMetadata pagingMetadata = new PagingMetadata(
                 pagedTransactions.getNumber(),
                 pagedTransactions.getSize(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface AccountTransactionQueryRepository {
 
     List<AccountTransactionProjection> findAccountTransactionWithJoins(PageRequest pageable);
+
+    long countTotalElements();
 }


### PR DESCRIPTION
# 수정 내용
## as-is
- allAccountTransactions 은 페이징 처리를 한 데이터인데 해당 데이터로 PageImpl 객체를 만듦
- new PageImpl<>(allAccountTransactions, pageable, allAccountTransactions.size());
- totalElements, totalPages 값이 전체 데이터 기준이 아닌 페이징 처리 한 데이터 기준으로 설정됨

## to-be
- 모든 데이터를 카운팅 하는 메서드를 생성하여 전체 데이터 갯수를 구함
- new PageImpl<>(allAccountTransactions, pageable, totalElements);