### PR TITLE
[FIX] 입출금 내역 저장 API 

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionMapper.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionMapper.java
@@ -1,6 +1,7 @@
 package com.github.kellyihyeon.stanceadmin.application.accounttransaction;
 
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.AccountTransaction;
+import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionIdentity;
 import com.github.kellyihyeon.stanceadmin.infrastructure.entity.accounttransaction.AccountTransactionEntity;
 
 import java.util.Objects;
@@ -13,6 +14,7 @@ public class AccountTransactionMapper {
                 domain.getTransactionType(),
                 domain.getTransactionId(),
                 domain.getTransactionSubType(),
+                domain.getTransactionDate(),
                 domain.getAmount(),
                 domain.getBalance(),
                 domain.getCreatedAt(),
@@ -24,13 +26,17 @@ public class AccountTransactionMapper {
         if (Objects.isNull(entity)) {
             return null;
         }
+        TransactionIdentity transactionIdentity = TransactionIdentity.create(
+                entity.getTransactionId(),
+                entity.getTransactionType(),
+                entity.getTransactionSubType(),
+                entity.getTransactionDate()
+        );
 
-        return AccountTransaction.create(
+        return AccountTransaction.createWithId(
                 entity.getId(),
                 entity.getAccountId(),
-                entity.getTransactionType(),
-                entity.getTransactionId(),
-                entity.getTransactionSubType(),
+                transactionIdentity,
                 entity.getAmount(),
                 entity.getBalance(),
                 entity.getCreatedAt(),

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionService.java
@@ -30,16 +30,12 @@ public class AccountTransactionService {
         Long loggedInId = 999L;
 
         Long defaultAccountId = accountService.getDefaultAccount().getId();
-        AccountTransaction accountTransaction = AccountTransaction.create(
+        AccountTransaction accountTransaction = AccountTransaction.createWithoutId(
                 defaultAccountId,
-                transactionIdentity.getType(),
-                transactionIdentity.getTransactionId(),
-                transactionIdentity.getSubtype(),
+                transactionIdentity,
                 amount,
                 now,
-                loggedInId
-        );
-
+                loggedInId);
         accountTransaction.calculateBalance(getLatestBalance());
         repository.saveAccountTransaction(accountTransaction);
         log.debug("AccountTransaction saved successfully. The event will be triggered. [new balance is {}]", accountTransaction.getBalance());

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/bankdeposit/BankDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/bankdeposit/BankDepositTransactionService.java
@@ -31,7 +31,13 @@ public class BankDepositTransactionService {
         BankDepositTransaction bankDepositTransaction = mapper.toDomain(serviceDto, loggedInId, now);
         BankDepositTransaction persistedBankDepositTransaction = repository.saveBankDepositTransaction(bankDepositTransaction);
 
-        TransactionIdentity transactionIdentity = TransactionIdentity.create(persistedBankDepositTransaction.getId(), TransactionType.DEPOSIT, TransactionSubType.BANK);
+        TransactionIdentity transactionIdentity = TransactionIdentity.create(
+                persistedBankDepositTransaction.getId(),
+                TransactionType.DEPOSIT,
+                TransactionSubType.BANK,
+                persistedBankDepositTransaction.getDepositDate()
+        );
+
         accountTransactionService.saveAccountTransaction(transactionIdentity, persistedBankDepositTransaction.getAmount());
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/cardpayment/CardPaymentTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/cardpayment/CardPaymentTransactionService.java
@@ -32,7 +32,8 @@ public class CardPaymentTransactionService {
         TransactionIdentity transactionIdentity = TransactionIdentity.create(
                 cardPaymentTransaction.getId(),
                 TransactionType.WITHDRAW,
-                TransactionSubType.CARD_PAYMENT
+                TransactionSubType.CARD_PAYMENT,
+                cardPaymentTransaction.getExpenseDate()
         );
         accountTransactionService.saveAccountTransaction(transactionIdentity, cardPaymentTransaction.getAmount().doubleValue());
     }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventFeeDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/eventdeposit/EventFeeDepositTransactionService.java
@@ -58,8 +58,14 @@ public class EventFeeDepositTransactionService {
 
             eventApplicantRegistryService.processDepositCompletion(serviceDto.getEventId(), serviceDto.getDepositorIds());
 
+            // TODO: repository 에 저장된 entity 의 deposit date 를 파라미터로 넘길 것
             accountTransactionService.saveAccountTransaction(
-                    TransactionIdentity.create(transactionId, TransactionType.DEPOSIT, TransactionSubType.EVENT),
+                    TransactionIdentity.create(
+                            transactionId,
+                            TransactionType.DEPOSIT,
+                            TransactionSubType.EVENT,
+                            eventDepositTransaction.getDepositDate()
+                            ),
                     serviceDto.getAmount()
             );
         }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
@@ -82,8 +82,14 @@ public class MembershipFeeDepositTransactionService {
         for (MembershipFeeDepositTransaction domain : transactions) {
             Long transactionId = repository.createMembershipFeeDepositTransaction(domain);
 
+            // TODO: repository 에 저장된 entity 의 deposit date 를 파라미터로 넘길 것
             accountTransactionService.saveAccountTransaction(
-                    TransactionIdentity.create(transactionId, TransactionType.DEPOSIT, TransactionSubType.MEMBERSHIP_FEE),
+                    TransactionIdentity.create(
+                            transactionId,
+                            TransactionType.DEPOSIT,
+                            TransactionSubType.MEMBERSHIP_FEE,
+                            domain.getDepositDate()
+                            ),
                     serviceDto.amount()
             );
         }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/transfertransaction/TransferTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/transfertransaction/TransferTransactionService.java
@@ -32,7 +32,9 @@ public class TransferTransactionService {
         TransactionIdentity transactionIdentity = TransactionIdentity.create(
                 transferTransaction.getId(),
                 TransactionType.WITHDRAW,
-                TransactionSubType.TRANSFER
+                TransactionSubType.TRANSFER,
+                transferTransaction.getExpenseDate()
+
         );
         accountTransactionService.saveAccountTransaction(transactionIdentity, transferTransaction.getAmount().doubleValue());
     }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransaction.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -15,6 +16,8 @@ public class AccountTransaction {
     private Long id;
 
     private Long accountId;
+
+    private LocalDate transactionDate;
 
     private TransactionType transactionType;
 
@@ -30,74 +33,63 @@ public class AccountTransaction {
 
     private Long creatorId;
 
-
-    private AccountTransaction(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
+    private AccountTransaction(Long id, Long accountId, TransactionIdentity transactionIdentity, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
         this.id = id;
         this.accountId = accountId;
-        this.transactionType = transactionType;
-        this.transactionId = transactionId;
-        this.transactionSubType = transactionSubType;
+        this.transactionId = transactionIdentity.getTransactionId();
+        this.transactionType = transactionIdentity.getType();
+        this.transactionSubType = transactionIdentity.getSubtype();
+        this.transactionDate = transactionIdentity.getTransactionDate();
         this.amount = amount;
         this.balance = balance;
         this.createdAt = createdAt;
         this.creatorId = creatorId;
     }
 
-    private AccountTransaction(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, LocalDateTime createdAt, Long creatorId) {
-        this.id = id;
+    private AccountTransaction(Long accountId, TransactionIdentity transactionIdentity, Double amount, LocalDateTime createdAt, Long creatorId) {
         this.accountId = accountId;
-        this.transactionType = transactionType;
-        this.transactionId = transactionId;
-        this.transactionSubType = transactionSubType;
-        this.createdAt = createdAt;
-        this.creatorId = creatorId;
-    }
-
-    private AccountTransaction(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
-        this.accountId = accountId;
-        this.transactionType = transactionType;
-        this.transactionId = transactionId;
-        this.transactionSubType = transactionSubType;
+        this.transactionId = transactionIdentity.getTransactionId();
+        this.transactionType = transactionIdentity.getType();
+        this.transactionSubType = transactionIdentity.getSubtype();
+        this.transactionDate = transactionIdentity.getTransactionDate();
         this.amount = amount;
         this.createdAt = createdAt;
         this.creatorId = creatorId;
     }
 
-    public static AccountTransaction create(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, LocalDateTime createdAt, Long creatorId) {
-        Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionType, "transactionType 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionId, "transactionId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionSubType, "transactionSubType 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
-
-        return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, createdAt, creatorId);
-    }
-
-    public static AccountTransaction create(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, LocalDateTime createdAt, Long creatorId) {
-        Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionType, "transactionType 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionId, "transactionId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionSubType, "transactionSubType 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(amount, "amount 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
-
-        return new AccountTransaction(accountId, transactionType, transactionId, transactionSubType, amount, createdAt, creatorId);
-    }
-
-    public static AccountTransaction create(Long id, Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
+    public static AccountTransaction createWithId(Long id, Long accountId, TransactionIdentity transactionIdentity, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
         Objects.requireNonNull(id, "id 가 null 이어서는 안됩니다.");
         Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionType, "transactionType 이 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionId, "transactionId 가 null 이어서는 안됩니다.");
-        Objects.requireNonNull(transactionSubType, "transactionSubType 이 null 이어서는 안됩니다.");
+        validateTransactionIdentity(transactionIdentity);
         Objects.requireNonNull(amount, "amount 가 null 이어서는 안됩니다.");
         Objects.requireNonNull(balance, "balance 가 null 이어서는 안됩니다.");
         Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
         Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
 
-        return new AccountTransaction(id, accountId, transactionType, transactionId, transactionSubType, amount, balance, createdAt, creatorId);
+        return new AccountTransaction(id, accountId, transactionIdentity, amount, balance, createdAt, creatorId);
+    }
+
+    public static AccountTransaction createWithoutId(Long accountId, TransactionIdentity transactionIdentity, Double amount, LocalDateTime createdAt, Long creatorId) {
+        Objects.requireNonNull(accountId, "accountId 가 null 이어서는 안됩니다.");
+        validateTransactionIdentity(transactionIdentity);
+        Objects.requireNonNull(amount, "amount 가 null 이어서는 안됩니다.");
+        Objects.requireNonNull(createdAt, "createdAt 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(creatorId, "creatorId 가 null 이어서는 안됩니다.");
+
+        return new AccountTransaction(
+                accountId,
+                transactionIdentity,
+                amount,
+                createdAt,
+                creatorId
+        );
+    }
+
+    private static void validateTransactionIdentity(TransactionIdentity transactionIdentity) {
+        Objects.requireNonNull(transactionIdentity.getTransactionId(), "transactionId 가 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionIdentity.getType(), "transactionType 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionIdentity.getSubtype(), "transactionSubType 이 null 이어서는 안됩니다.");
+        Objects.requireNonNull(transactionIdentity.getTransactionDate(), "transactionDate 가 null 이어서는 안됩니다.");
     }
 
     public BigDecimal calculateBalance(BigDecimal latestBalance) {

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/TransactionIdentity.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.Objects;
 
 @Getter
@@ -16,18 +17,21 @@ public class TransactionIdentity {
 
     private TransactionSubType subtype;
 
+    private LocalDate transactionDate;
 
-    private TransactionIdentity(Long transactionId, TransactionType type, TransactionSubType subtype) {
+    private TransactionIdentity(Long transactionId, TransactionType type, TransactionSubType subtype, LocalDate transactionDate) {
         this.transactionId = transactionId;
         this.type = type;
         this.subtype = subtype;
+        this.transactionDate = transactionDate;
     }
 
-    public static TransactionIdentity create(Long transactionId, TransactionType type, TransactionSubType subtype) {
+    public static TransactionIdentity create(Long transactionId, TransactionType type, TransactionSubType subtype, LocalDate transactionDate) {
         Objects.requireNonNull(transactionId, "transactionId 가 null 이어선 안됩니다.");
         Objects.requireNonNull(type, "type 이 null 이어선 안됩니다.");
         Objects.requireNonNull(subtype, "subtype 이 null 이어선 안됩니다.");
+        Objects.requireNonNull(transactionDate, "transactionDate 가 null 이어선 안됩니다.");
 
-        return new TransactionIdentity(transactionId, type, subtype);
+        return new TransactionIdentity(transactionId, type, subtype, transactionDate);
     }
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/entity/accounttransaction/AccountTransactionEntity.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/entity/accounttransaction/AccountTransactionEntity.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AfterDomainEventPublication;
 import org.springframework.data.domain.DomainEvents;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,6 +30,9 @@ public class AccountTransactionEntity {
 
     @Column(name = "account_id", nullable = false)
     private Long accountId;
+
+    @Column(name = "transaction_date", nullable = false)
+    private LocalDate transactionDate;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "transcation_type", nullable = false)
@@ -56,11 +60,12 @@ public class AccountTransactionEntity {
     @Transient
     private final List<Object> accountTransactionDomainEvents = new ArrayList<>();
 
-    public AccountTransactionEntity(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
+    public AccountTransactionEntity(Long accountId, TransactionType transactionType, Long transactionId, TransactionSubType transactionSubType, LocalDate transactionDate, Double amount, Double balance, LocalDateTime createdAt, Long creatorId) {
         this.accountId = accountId;
         this.transactionType = transactionType;
         this.transactionId = transactionId;
         this.transactionSubType = transactionSubType;
+        this.transactionDate = transactionDate;
         this.amount = amount;
         this.balance = balance;
         this.createdAt = createdAt;

--- a/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
+++ b/src/test/java/com/github/kellyihyeon/stanceadmin/domain/accounttransaction/AccountTransactionBuilder.java
@@ -1,5 +1,6 @@
 package com.github.kellyihyeon.stanceadmin.domain.accounttransaction;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class AccountTransactionBuilder {
@@ -13,6 +14,8 @@ public class AccountTransactionBuilder {
     private Long transactionId = 1L;
 
     private TransactionSubType transactionSubType = TransactionSubType.MEMBERSHIP_FEE;
+
+    private LocalDate transactionDate = LocalDate.now();
 
     private Double amount = (double) 1000;
 
@@ -60,11 +63,16 @@ public class AccountTransactionBuilder {
     }
 
     public AccountTransaction build() {
-        return AccountTransaction.create(
-                accountId,
-                transactionType,
+        TransactionIdentity transactionIdentity = TransactionIdentity.create(
                 transactionId,
+                transactionType,
                 transactionSubType,
+                transactionDate
+        );
+
+        return AccountTransaction.createWithoutId(
+                accountId,
+                transactionIdentity,
                 amount,
                 createdAt,
                 creatorId


### PR DESCRIPTION
# 수정 내용
## as-is
- AccountTransaction 도메인에 transactionDate 필드가 없었음

## to-be
- 도메인과 엔티티에 transactionDate 필드 추가
- 입출금 내역을 저장하는 로직에 transactionDate도 추가