### PR TITLE
[FIX] 입출금 거래 내역 전체 조회

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionQueryService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/accounttransaction/AccountTransactionQueryService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ public class AccountTransactionQueryService {
                     response.transactionParty(projection.getTransactionParty());
                     response.amount(projection.getAmount());
                     response.balance(projection.getBalance());
+                    response.createdAt(Timestamp.valueOf(projection.getCreatedAt()));
 
                     return response;
                 })

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/querydsl/AccountTransactionProjection.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/querydsl/AccountTransactionProjection.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
@@ -25,5 +26,7 @@ public class AccountTransactionProjection {
     private Double amount;
 
     private Double balance;
+
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
@@ -101,7 +101,8 @@ public class AccountTransactionQueryRepositoryImpl implements AccountTransaction
                                         .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.EVENT))
                                         .then(eventEntity.eventItem.stringValue())
                                         .otherwise(accountTransactionEntity.transactionSubType.stringValue())
-                                        .as("detailType")
+                                        .as("detailType"),
+                                accountTransactionEntity.createdAt
                         )
 
                 );

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static com.github.kellyihyeon.stanceadmin.infrastructure.entity.accounttransaction.QAccountTransactionEntity.accountTransactionEntity;
@@ -70,7 +69,8 @@ public class AccountTransactionQueryRepositoryImpl implements AccountTransaction
                                 ))
                 .leftJoin(eventEntity)
                 .on(accountTransactionEntity.transactionSubType.eq(TransactionSubType.EVENT)
-                        .and(eventEntity.id.eq(eventDepositTransactionEntity.eventId)));
+                        .and(eventEntity.id.eq(eventDepositTransactionEntity.eventId)))
+                .orderBy(accountTransactionEntity.transactionDate.desc());
     }
 
     private JPAQuery<AccountTransactionProjection> buildSelectQuery() {
@@ -96,19 +96,7 @@ public class AccountTransactionQueryRepositoryImpl implements AccountTransaction
                                         .then(transferTransactionEntity.recipientName)
                                         .otherwise(Expressions.constant("없음"))
                                         .as("transactionParty"),
-                                new CaseBuilder()
-                                        .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.MEMBERSHIP_FEE))
-                                        .then(memberShipFeeDepositTransactionEntity.depositDate)
-                                        .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.BANK))
-                                        .then(bankDepositTransactionEntity.depositDate)
-                                        .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.EVENT))
-                                        .then(eventDepositTransactionEntity.depositDate)
-                                        .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.CARD_PAYMENT))
-                                        .then(cardPaymentTransactionEntity.expenseDate)
-                                        .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.TRANSFER))
-                                        .then(transferTransactionEntity.expenseDate)
-                                        .otherwise(LocalDate.of(1900,1,1))
-                                        .as("transactionDate"),
+                                accountTransactionEntity.transactionDate,
                                 new CaseBuilder()
                                         .when(accountTransactionEntity.transactionSubType.eq(TransactionSubType.EVENT))
                                         .then(eventEntity.eventItem.stringValue())

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -846,6 +846,19 @@ components:
         balance:
           type: number
           format: double
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - transactionId
+        - transactionType
+        - detailType
+        - transactionDate
+        - transactionParty
+        - amount
+        - balance
+        - createdAt
 
     EventSummaryResponse:
       type: object


### PR DESCRIPTION
# 수정 내용
## as-is
- transactionDate를 select query문 작성할 때 분기문으로 작성해서 매핑함
- 테이블에 저장된 순으로 데이터 조회

## to-be
- transactionDate가 accountTransactions 테이블의 필드로 추가되었으므로 테이블에서 바로 가져옴
- 거래일 기준으로 최신순으로 정렬