### PR TITLE
[프론트-FIX] 회비 등록 API 호출

### DIFF
--- a/src/main/resources/static/js/membershipFeeRegistraion.js
+++ b/src/main/resources/static/js/membershipFeeRegistraion.js
@@ -32,6 +32,7 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         let selectedDepositors = [];
+        let dueDate = '';
 
         document.getElementById('membershipFeeForm').addEventListener('submit', function (event) {
             event.preventDefault();
@@ -48,6 +49,8 @@ document.addEventListener('DOMContentLoaded', function () {
             checkedBoxes.forEach(checkedBox => {
                 selectedDepositors.push(checkedBox.value)
             });
+
+            dueDate = document.getElementById('dueDate').value;
 
             const membershipFeePermissionModal = new bootstrap.Modal(document.getElementById('membershipFeePermissionModal'));
             membershipFeePermissionModal.show();
@@ -72,7 +75,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 depositorIds: selectedDepositors,
                 depositDate: document.getElementById('depositDate').value,
                 amount: document.getElementById('amount').value,
-                dueDate: document.getElementById('dueDate').value,
+                dueDate,
                 memberType: document.getElementById('membershipType').value,
                 description: document.getElementById('description').value
             }


### PR DESCRIPTION
# 수정 내용
## 문제 상황
- 현재 월의 25일이 만료일의 기본 데이터로 설정되어 있으나 사용자가 만료일 변경 시 변경된 날짜가 만료일이 되어야 함
- 하지만 사용자가 만료일을 변경해도 기본 고정 만료일이 서버로 전달됨

## 해결
- 만료일 변수를 전역으로 설정하여 데이터를 미리 저장해 둠
- 폼 제출 시 변경된 만료일이 서버로 전송됨