### PR TITLE
[FIX] 모임통장 내역 조회 및 등록

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/accounttransaction/AccountTransactionQueryRepositoryImpl.java
@@ -70,7 +70,10 @@ public class AccountTransactionQueryRepositoryImpl implements AccountTransaction
                 .leftJoin(eventEntity)
                 .on(accountTransactionEntity.transactionSubType.eq(TransactionSubType.EVENT)
                         .and(eventEntity.id.eq(eventDepositTransactionEntity.eventId)))
-                .orderBy(accountTransactionEntity.transactionDate.desc());
+                .orderBy(
+                        accountTransactionEntity.transactionDate.desc(),
+                        accountTransactionEntity.createdAt.desc()
+                );
     }
 
     private JPAQuery<AccountTransactionProjection> buildSelectQuery() {

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1116,8 +1116,9 @@ components:
           type: string
           enum:
             - ACTIVE
-            - INACTIVE
+            - DORMANT
             - GUEST
+            - COACH
         description:
           type: string
       required:


### PR DESCRIPTION
# 수정 내용
## as-is
- 회비 등록 시 멤버십 유형 이넘 타입에 휴면회원을 INACTIVE 로 정의
- 모임통장 전체 내역 조회 시 거래일 기준으로 최신 정렬

## to-be
- 멤버십 유형 이넘 타입
    - 휴면회원 -> DORMANT 로 정의
    - 코치 COACH 추가
- 모임통장 전체 내역 조회 시 거래일이 같을 경우 생성일 최신 정렬 조건 추가