### PR TITLE
[FIX] 회비 입금 현황 조회 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
@@ -3,11 +3,13 @@ package com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit;
 import com.github.kellyihyeon.stanceadmin.application.accounttransaction.AccountTransactionService;
 import com.github.kellyihyeon.stanceadmin.application.accounttransaction.dto.MemberShipFeeDepositCreation;
 import com.github.kellyihyeon.stanceadmin.application.member.MemberService;
+import com.github.kellyihyeon.stanceadmin.application.member.dto.MemberSummaryResponse;
 import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.dto.DepositDateCondition;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionIdentity;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionSubType;
 import com.github.kellyihyeon.stanceadmin.domain.accounttransaction.TransactionType;
 import com.github.kellyihyeon.stanceadmin.domain.eventapplicantregistry.DepositStatus;
+import com.github.kellyihyeon.stanceadmin.domain.member.Member;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRegistry;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRepository;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositTransaction;
@@ -98,13 +100,15 @@ public class MembershipFeeDepositTransactionService {
     public DepositRateResponse getDepositRate(DepositDateCondition depositDateCondition) {
         validateDepositDate(depositDateCondition);
 
-        YearMonth yearMonth = YearMonth.of(depositDateCondition.year(), depositDateCondition.month());
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
+        YearMonth dueDate = YearMonth.of(depositDateCondition.year(), depositDateCondition.month() - 1);
+        LocalDate startDate = dueDate.atDay(1);
+        LocalDate endDate = dueDate.atEndOfMonth();
 
-        int totalPaidMembers = repository.findPaidMembers(startDate, endDate).size();
-        int totalParticipatingMembers = memberService.getParticipatingMembers().size();
+        List<Member> paidMembers = repository.findPaidMembers(startDate, endDate);
+        List<MemberSummaryResponse> participatingMembers = memberService.getParticipatingMembers();
 
+        int totalPaidMembers = paidMembers.size();
+        int totalParticipatingMembers = participatingMembers.size();
         int depositRatePercentage = calculateDepositRate(totalPaidMembers, totalParticipatingMembers);
 
         return new DepositRateResponse(

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.dto.D
 import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.dto.QDepositRegistryData;
 import com.github.kellyihyeon.stanceadmin.domain.member.Member;
 import com.github.kellyihyeon.stanceadmin.domain.member.MemberRole;
+import com.github.kellyihyeon.stanceadmin.domain.member.MemberType;
 import com.github.kellyihyeon.stanceadmin.domain.member.RegistrationStatus;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRegistry;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRepository;
@@ -52,6 +53,7 @@ public class MembershipFeeDepositRepositoryImpl implements MembershipFeeDepositR
                 .on(memberEntity.id.eq(memberShipFeeDepositTransactionEntity.depositorId)
                 )
                 .where(memberEntity.memberRole.eq(MemberRole.MEMBER)
+                        .and(memberShipFeeDepositTransactionEntity.memberType.in(MemberType.ACTIVE, MemberType.DORMANT))
                         .and(memberShipFeeDepositTransactionEntity.dueDate.between(startDate, endDate))
                         .and(memberEntity.registrationStatus.eq(RegistrationStatus.REGISTERED))
                 )


### PR DESCRIPTION
# 수정 내용
## as-is
- 해당월의 회비 입금자 조회 시 만료일 조건을 해당월로 설정
   - 2024년 10월 회비 입금 현황을 조회 하면  만료일이 해당월인 데이터를 필터링함 (10월 현황 : 만료일이 10월)
- 회비 입금자 조회 시 회원 유형 조건이 없어서 게스트가 낸 회비도 카운팅 됨

## to-be
- 해당월의 회비 입금자 조회 시 만료일을 조건으로 설정
   - 2024년 10월 회비 입금 현황을 조회 하면  만료일이 해당월의 전월인 데이터를 필터링함 (10월 현황 : 만료일이 9월)
- 회비 입금자 조회 시 회원 유형 조건을 ACTIVE, DORMANT 로 제한하여 활동 중인 회원만 카운팅 되도록 함