### PR TITLE
[FIX] 회비 입금 명단 조회 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/application/membershipfeedeposit/MembershipFeeDepositTransactionService.java
@@ -37,9 +37,9 @@ public class MembershipFeeDepositTransactionService {
     public List<MembershipFeePayerResponse> getMembershipFeePayersByDepositStatus(DepositStatus status, DepositDateCondition depositDateCondition) {
         validateDepositDate(depositDateCondition);
 
-        YearMonth yearMonth = YearMonth.of(depositDateCondition.year(), depositDateCondition.month());
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
+        YearMonth dueDate = YearMonth.of(depositDateCondition.year(), depositDateCondition.month() - 1);
+        LocalDate startDate = dueDate.atDay(1);
+        LocalDate endDate = dueDate.atEndOfMonth();
 
         List<MembershipFeeDepositRegistry> registries = repository.getDepositRegistries(startDate, endDate);
         List<MembershipFeeDepositRegistry> confirmedDepositRecords = checkDepositInformation(registries);

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
@@ -82,6 +82,7 @@ public class MembershipFeeDepositRepositoryImpl implements MembershipFeeDepositR
                         .and(memberEntity.memberStatus.in(MemberStatus.ACTIVE, MemberStatus.DORMANT))
                         .and(memberEntity.registrationStatus.eq(RegistrationStatus.REGISTERED))
                 )
+                .orderBy(memberShipFeeDepositTransactionEntity.depositDate.desc())
                 .fetch();
 
         return registryMapper.toDomains(registryDataDto);

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/membershipfeedeposit/MembershipFeeDepositRepositoryImpl.java
@@ -5,10 +5,7 @@ import com.github.kellyihyeon.stanceadmin.application.member.MemberMapper;
 import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.MembershipFeeDepositRegistryMapper;
 import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.dto.DepositRegistryData;
 import com.github.kellyihyeon.stanceadmin.application.membershipfeedeposit.dto.QDepositRegistryData;
-import com.github.kellyihyeon.stanceadmin.domain.member.Member;
-import com.github.kellyihyeon.stanceadmin.domain.member.MemberRole;
-import com.github.kellyihyeon.stanceadmin.domain.member.MemberType;
-import com.github.kellyihyeon.stanceadmin.domain.member.RegistrationStatus;
+import com.github.kellyihyeon.stanceadmin.domain.member.*;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRegistry;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositRepository;
 import com.github.kellyihyeon.stanceadmin.domain.membershipfeedeposit.MembershipFeeDepositTransaction;
@@ -82,6 +79,7 @@ public class MembershipFeeDepositRepositoryImpl implements MembershipFeeDepositR
                         .and(memberShipFeeDepositTransactionEntity.dueDate.between(startDate, endDate))
                 )
                 .where(memberEntity.memberRole.eq(MemberRole.MEMBER)
+                        .and(memberEntity.memberStatus.in(MemberStatus.ACTIVE, MemberStatus.DORMANT))
                         .and(memberEntity.registrationStatus.eq(RegistrationStatus.REGISTERED))
                 )
                 .fetch();


### PR DESCRIPTION
# 수정 내용
## as-is
- 만료일을 해당월을 기준으로 데이터 필터링
- 회원 상태에 대한 조건이 없었기 때문에 게스트들이 명단에 올라옴

## to-be
- 만료일을 해당월의 전월 기준으로 데이터 필터링
- 회원 상태가 ACTIVE, DORMANT 인 멤버들만 필터링
- 최신 입금일 기준으로 데이터 정렬