### PR TITLE
[FIX] 이벤트 상태에 따른 조회 API

### DIFF
--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/event/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/event/EventQueryRepositoryImpl.java
@@ -28,7 +28,7 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
 
     @Override
     public List<Event> getEventsByStatus(EventStatus eventStatus) {
-        List<EventEntity> entities = jpaRepository.findByStatusOrderByDueDate(eventStatus);
+        List<EventEntity> entities = jpaRepository.findByStatusOrderByDueDateDesc(eventStatus);
         return mapper.toDomains(entities);
     }
 

--- a/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/event/JpaEventRepository.java
+++ b/src/main/java/com/github/kellyihyeon/stanceadmin/infrastructure/repository/event/JpaEventRepository.java
@@ -11,6 +11,6 @@ public interface JpaEventRepository extends JpaRepository<EventEntity, Long> {
 
     boolean existsByIdAndStatus(Long eventId, EventStatus eventStatus);
 
-    List<EventEntity> findByStatusOrderByDueDate(EventStatus eventStatus);
+    List<EventEntity> findByStatusOrderByDueDateDesc(EventStatus eventStatus);
 
 }


### PR DESCRIPTION
# 수정내용
- 이벤트 조회 시 만료일이 최신인 것을 기준으로 정렬